### PR TITLE
Ajuste de regreso a README

### DIFF
--- a/docs/InformeDesarrollo.md
+++ b/docs/InformeDesarrollo.md
@@ -15,5 +15,5 @@ Para mantener un historial detallado de cambios y mejoras, cada actualización o
 - **Archivos afectados:** `DocumentationUpdater.php`
 - [Saber más...](DocumentationUpdater.md)
 
-## [volver](README.md)
+## [volver](../README.md)
 


### PR DESCRIPTION
El enlace de regreso a README desde el informe de desarrollo estaba roto.